### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-calm-plant-0066bdd03.yml
+++ b/.github/workflows/azure-static-web-apps-calm-plant-0066bdd03.yml
@@ -1,4 +1,6 @@
 name: Azure Static Web Apps CI/CD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hftm-in2023/blogapp-20/security/code-scanning/9](https://github.com/hftm-in2023/blogapp-20/security/code-scanning/9)

To fix the problem, we should add an explicit `permissions` block specifying only the required minimum permissions for GITHUB_TOKEN. The optimal fix is to add the `permissions` block at the workflow level, just after the `name:` but before the `on:` key, so that all jobs inherit these permissions unless overridden. For this workflow, the minimal permissions are likely `contents: read` and, optionally, `pull-requests: write` (if the deployment action needs to update pull request statuses). If you are unsure, you can start with `contents: read` as suggested by CodeQL. This edit is made at the top of `.github/workflows/azure-static-web-apps-calm-plant-0066bdd03.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
