### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -6,6 +6,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/hftm-in2023/blogapp-20/security/code-scanning/7](https://github.com/hftm-in2023/blogapp-20/security/code-scanning/7)

To fix the problem, add an explicit `permissions` block to the workflow. You should add it at the workflow level (before `jobs:`), or for the specific job, and set only those permissions needed. For the JamesIves/github-pages-deploy-action, you typically need `contents: write` so that the workflow can push changes to the branch via the GITHUB_TOKEN. If no other actions require additional scopes, just grant `contents: write`. Add the following lines just above `jobs:` (after the triggers) in `.github/workflows/github-pages.yaml`:

```yaml
permissions:
  contents: write
```

This ensures the workflow runs with the minimum required permissions to deploy to GitHub Pages, aligning with security best practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
