### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hftm-in2023/blogapp-20/security/code-scanning/5](https://github.com/hftm-in2023/blogapp-20/security/code-scanning/5)

The optimal way to address this is to add a `permissions:` block that declares what access the GITHUB_TOKEN should have. For a typical CI build and test workflow (which does not publish, comment, or otherwise update repository resources), the least privilege needed is `contents: read`, which allows the workflow to check out code and access repository contents. No write access or other scopes are required. This block can be set at the workflow level (applies to all jobs), or at the job level (applies to just that job), but the provided snippet only contains a single job, so root-level is appropriate.  
You should add the following block directly after `name: Node.js CI` (line 4), before `on:`, to apply to all jobs in the workflow:

```yaml
permissions:
  contents: read
```

No new methods, imports, or complex modifications are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
