### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ng-update.yml
+++ b/.github/workflows/ng-update.yml
@@ -1,4 +1,7 @@
 name: "Update Angular Action"
+permissions:
+  contents: read
+  pull-requests: write
 on: # when the action should run. Can also be a CRON or in response to external events. see https://git.io/JeBz1
   schedule:
     - cron: "30 5 * * 3"


### PR DESCRIPTION
Potential fix for [https://github.com/hftm-in2023/blogapp-20/security/code-scanning/3](https://github.com/hftm-in2023/blogapp-20/security/code-scanning/3)

To fix this problem, you should add a `permissions` block to explicitly state the minimum required permissions for this workflow/job. The best practice is to set permissions as restrictive as possible—read-only for most workflows, but if this workflow needs to create or update pull requests (which is likely, since it "updates ng dependencies"), it specifically needs `contents: read` and `pull-requests: write` as a minimal set. The `permissions` block can be added at the root of the workflow (to apply to all jobs), or within the `ngxUptodate` job if that's the only job requiring elevated permissions. Since there is only one job, the root is preferred for clarity.

You should add:
```yaml
permissions:
  contents: read
  pull-requests: write
```
directly after the `name` and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
